### PR TITLE
Divides Math.sqrt(d)

### DIFF
--- a/chapter_attention-mechanisms/attention-scoring-functions.ipynb
+++ b/chapter_attention-mechanisms/attention-scoring-functions.ipynb
@@ -465,7 +465,7 @@
     "\n",
     "        Long d = queries.getShape().get(queries.getShape().dimension() - 1);\n",
     "        // Swap the last two dimensions of `keys` and perform batchDot\n",
-    "        NDArray scores = queries.batchDot(keys.swapAxes(1, 2)).div(Math.sqrt(2));\n",
+    "        NDArray scores = queries.batchDot(keys.swapAxes(1, 2)).div(Math.sqrt(d));\n",
     "        attentionWeights = maskedSoftmax(scores, validLens);\n",
     "        NDList list = dropout.forward(ps, new NDList(attentionWeights), training, params);\n",
     "        return new NDList(list.head().batchDot(values));\n",


### PR DESCRIPTION
The scaled dot-product attention scoring function need to divides the dot product by Math.sqrt(d).