### PR TITLE
fix: Update Image duplicate call to empty

### DIFF
--- a/chapter_computer-vision/anchor.ipynb
+++ b/chapter_computer-vision/anchor.ipynb
@@ -279,17 +279,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "https://github.com/tosterberg/d2l-java.git"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "origin_pos": 12

--- a/chapter_computer-vision/anchor.ipynb
+++ b/chapter_computer-vision/anchor.ipynb
@@ -182,7 +182,7 @@
    },
    "outputs": [],
    "source": [
-    "Image img2 = img.duplicate(Image.Type.TYPE_INT_ARGB);\n",
+    "Image img2 = img.duplicate();\n",
     "drawBBoxes(img2, boxes.get(250, 250),\n",
     "        new String[]{\"s=0.75, r=1\", \"s=0.5, r=1\", \"s=0.25, r=1\", \"s=0.75, r=2\", \"s=0.75, r=0.5\"});\n",
     "\n",
@@ -270,13 +270,24 @@
     "        {0.63f, 0.05f, 0.88f, 0.98f}, {0.66f, 0.45f, 0.8f, 0.8f},\n",
     "        {0.57f, 0.3f, 0.92f, 0.9f}});\n",
     "\n",
-    "Image img3 = img.duplicate(Image.Type.TYPE_INT_ARGB);\n",
+    "Image img3 = img.duplicate();\n",
     "\n",
     "drawBBoxes(img3, groundTruth.get(new NDIndex(\":, 1:\")), new String[]{\"dog\", \"cat\"});\n",
     "drawBBoxes(img3, anchors, new String[]{\"0\", \"1\", \"2\", \"3\", \"4\"});\n",
     "\n",
     "img3.getWrappedImage()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "https://github.com/tosterberg/d2l-java.git"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
@@ -462,7 +473,7 @@
    },
    "outputs": [],
    "source": [
-    "Image img4 = img.duplicate(Image.Type.TYPE_INT_ARGB);\n",
+    "Image img4 = img.duplicate();\n",
     "drawBBoxes(img4, anchors, new String[]{\"dog=0.9\", \"dog=0.8\", \"dog=0.7\", \"cat=0.9\"});\n",
     "\n",
     "img4.getWrappedImage()"
@@ -525,7 +536,7 @@
    },
    "outputs": [],
    "source": [
-    "Image img5 = img.duplicate(Image.Type.TYPE_INT_ARGB);\n",
+    "Image img5 = img.duplicate();\n",
     "for (int i = 0; i < output.size(1); i++) {\n",
     "    NDArray bbox = output.get(0, i);\n",
     "    // Skip prediction bounding boxes of category -1\n",

--- a/chapter_computer-vision/multiscale-object-detection.ipynb
+++ b/chapter_computer-vision/multiscale-object-detection.ipynb
@@ -106,7 +106,7 @@
    },
    "outputs": [],
    "source": [
-    "Image img2 = img.duplicate(Image.Type.TYPE_INT_ARGB);\n",
+    "Image img2 = img.duplicate();\n",
     "displayAnchors(img2, 4, 4, Arrays.asList(0.15f));\n",
     "\n",
     "img2.getWrappedImage()"
@@ -137,7 +137,7 @@
    },
    "outputs": [],
    "source": [
-    "Image img3 = img.duplicate(Image.Type.TYPE_INT_ARGB);\n",
+    "Image img3 = img.duplicate();\n",
     "displayAnchors(img3, 2, 2, Arrays.asList(0.4f));\n",
     "\n",
     "img3.getWrappedImage()"
@@ -168,7 +168,7 @@
    },
    "outputs": [],
    "source": [
-    "Image img4 = img.duplicate(Image.Type.TYPE_INT_ARGB);\n",
+    "Image img4 = img.duplicate();\n",
     "displayAnchors(img4, 1, 1, Arrays.asList(0.8f));\n",
     "\n",
     "img4.getWrappedImage()"


### PR DESCRIPTION
Fix: Computer Vision notebooks updated to match the Image duplicate method call for 0.20.0