### PR TITLE
Clear gradients from the previous batch in linear regression

### DIFF
--- a/chapter_linear-networks/linear-regression-scratch.ipynb
+++ b/chapter_linear-networks/linear-regression-scratch.ipynb
@@ -521,6 +521,8 @@
     "        NDArray y = batch.getLabels().head();\n",
     "        \n",
     "        try (GradientCollector gc = Engine.getInstance().newGradientCollector()) {\n",
+    "            // Clear the gradients from the previous batch\n",
+    "            gc.zeroGradients();\n",
     "            // Minibatch loss in X and y\n",
     "            NDArray l = squaredLoss(linreg(X, params.get(0), params.get(1)), y);\n",
     "            gc.backward(l);  // Compute gradient on l with respect to w and b\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In section 3.2.7 on Linear Regression Training, the gradients should be cleared before each batch, or they will keep accumulating. 