### PR TITLE
fix #203 Corrected the figue for Loss Function in Linear Regression

### DIFF
--- a/chapter_linear-networks/linear-regression.ipynb
+++ b/chapter_linear-networks/linear-regression.ipynb
@@ -167,7 +167,7 @@
     "where we plot a regression problem for a one-dimensional case\n",
     "as shown in :numref:`fig_fit_linreg`.\n",
     "\n",
-    "![Fit data with a linear model.](https://resources.djl.ai/d2l-java/Neuron.svg)\n",
+    "![Fit data with a linear model.](https://resources.djl.ai/d2l-java/fit_linreg.svg)\n",
     ":label:`fig_fit_linreg`\n",
     "\n",
     "Note that large differences between\n",


### PR DESCRIPTION
*Issue #203:*

*Description of changes:*

Corrected the URL of the figure for "Loss Function" in chapter "Linear Regression".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
