### PR TITLE
resolve IJava kernel stuck at "Connecting" in Google Colab

### DIFF
--- a/tools/colab_build.sh
+++ b/tools/colab_build.sh
@@ -6,6 +6,8 @@ apt-get install -q openjdk-11-jdk-headless &> /dev/null
 echo "Install Jupyter java kernel..."
 curl -L https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip -o ijava-kernel.zip &> /dev/null
 unzip -q ijava-kernel.zip -d ijava-kernel && cd ijava-kernel && python3 install.py --sys-prefix &> /dev/null
+wget -qO- https://gist.github.com/SpencerPark/e2732061ad19c1afa4a33a58cb8f18a9/archive/b6cff2bf09b6832344e576ea1e4731f0fb3df10c.tar.gz | tar xvz --strip-components=1
+python install_ipc_proxy_kernel.py --kernel=java --implementation=ipc_proxy_kernel.py
 cd ..
 git clone https://github.com/deepjavalibrary/d2l-java &> /dev/null
 cp -r d2l-java/utils ../


### PR DESCRIPTION
*Issue #, if available:*
When using tools/colab_build.sh to install the IJava kernel in Google Colab, the notebook becomes stuck at the "Connecting" because of changes to Google Colab defaults in Dec. 2022 : Colab has transitioned its default transport protocol from TCP to IPC, which is not supported by IJava. 

References:
1.  https://stackoverflow.com/questions/74674688/google-colab-notebook-using-ijava-stuck-at-connecting-after-installation-ref

2.  https://medium.com/@gmsharpe/getting-started-with-tablesaw-and-google-colab-65ef0cbe280c




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
