### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/canary_d2l.yml
+++ b/.github/workflows/canary_d2l.yml
@@ -6,6 +6,9 @@ on:
     - cron:  '0 9 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   canary-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -6,6 +6,9 @@ on:
     - cron:  '0 9 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_notebook.yml
+++ b/.github/workflows/pr_notebook.yml
@@ -10,6 +10,9 @@ on:
       - "**.css"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.